### PR TITLE
Fix link to beepy homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 DESCRIPTION
 ===========
 Installs a DirectFB toolchain for the beepy open hardware platform described here:
-  * https://beepy.sqmfi.com
-  * https://github.com/beeper/beepberry
+  * [https://beepy.sqfmi.com](https://beepy.sqfmi.com)
+  * [https://github.com/beeper/beepberry](https://github.com/beeper/beepberry)
 
 QUICK SETUP (skipping important details)
 ========================================


### PR DESCRIPTION
Previously the link was to beepy.sqmfi.com and this PR fixes to beepy.sqfmi.com

Also made the hyperlinks clickable